### PR TITLE
Support multi channel model.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>TrackMate</artifactId>
-			<version>7.3.0</version>
+			<version>7.6.1</version>
 		</dependency>
 		
 		<!-- Ilastik & friends -->

--- a/src/main/java/fiji/plugin/trackmate/ilastik/IlastikDetector.java
+++ b/src/main/java/fiji/plugin/trackmate/ilastik/IlastikDetector.java
@@ -40,8 +40,6 @@ public class IlastikDetector< T extends RealType< T > & NativeType< T > > implem
 
 	protected final Interval interval;
 
-	protected final double[] calibration;
-
 	protected final String classifierPath;
 
 	protected final int classIndex;
@@ -56,17 +54,36 @@ public class IlastikDetector< T extends RealType< T > & NativeType< T > > implem
 
 	protected SpotCollection spots;
 
+	private final int channel;
+
+	/**
+	 * Instantiate an ilastik detector.
+	 * 
+	 * @param img
+	 *            source image, possibly multiple frames, possibly multiple Zs,
+	 *            possibly multiple channels.
+	 * @param interval
+	 *            the interval on which to operate.
+	 * @param calibration
+	 *            the pixel sizes.
+	 * @param classifierPath
+	 *            the path to the ilastik project containing the classifier.
+	 * @param classIndex
+	 *            the index of the class to extract.
+	 * @param probaThreshold
+	 *            a threshold on the probability map to extract objects.
+	 */
 	public IlastikDetector(
 			final ImgPlus< T > img,
 			final Interval interval,
-			final double[] calibration,
+			final int channel,
 			final String classifierPath,
 			final int classIndex,
 			final double probaThreshold )
 	{
 		this.img = img;
 		this.interval = interval;
-		this.calibration = calibration;
+		this.channel = channel;
 		this.classifierPath = classifierPath;
 		this.classIndex = classIndex;
 		this.probaThreshold = probaThreshold;
@@ -87,7 +104,7 @@ public class IlastikDetector< T extends RealType< T > & NativeType< T > > implem
 			spots = IlastikRunner.run(
 					img,
 					interval,
-					calibration,
+					channel,
 					classifierPath,
 					classIndex,
 					probaThreshold );

--- a/src/main/java/fiji/plugin/trackmate/ilastik/IlastikDetectorConfigurationPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/ilastik/IlastikDetectorConfigurationPanel.java
@@ -270,6 +270,7 @@ public class IlastikDetectorConfigurationPanel extends IlastikDetectorBaseConfig
 
 		final JLabelLogger labelLogger = new JLabelLogger();
 		final GridBagConstraints gbc_labelLogger = new GridBagConstraints();
+		gbc_labelLogger.fill = GridBagConstraints.HORIZONTAL;
 		gbc_labelLogger.gridwidth = 3;
 		gbc_labelLogger.gridx = 0;
 		gbc_labelLogger.gridy = 10;

--- a/src/main/java/fiji/plugin/trackmate/ilastik/IlastikDetectorConfigurationPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/ilastik/IlastikDetectorConfigurationPanel.java
@@ -40,13 +40,17 @@ import java.io.File;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.swing.JButton;
 import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JSlider;
+import javax.swing.JSpinner;
+import javax.swing.JSpinner.DefaultEditor;
 import javax.swing.JTextField;
+import javax.swing.SpinnerListModel;
 import javax.swing.SwingConstants;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -75,8 +79,6 @@ public class IlastikDetectorConfigurationPanel extends IlastikDetectorBaseConfig
 
 	private final JSlider sliderChannel;
 
-	private final JSlider sliderClassId;
-
 	private final JTextField modelFileTextField;
 
 	private final JButton btnBrowse;
@@ -84,6 +86,8 @@ public class IlastikDetectorConfigurationPanel extends IlastikDetectorBaseConfig
 	private final JFormattedTextField ftfProbaThreshold;
 
 	protected final PrefService prefService;
+
+	private final JSpinner spinner;
 
 	/**
 	 * Create the panel.
@@ -102,24 +106,24 @@ public class IlastikDetectorConfigurationPanel extends IlastikDetectorBaseConfig
 
 		final JLabel lblSettingsForDetector = new JLabel( "Settings for detector:" );
 		lblSettingsForDetector.setFont( FONT );
-		final GridBagConstraints gbc_lblSettingsForDetector = new GridBagConstraints();
-		gbc_lblSettingsForDetector.gridwidth = 3;
-		gbc_lblSettingsForDetector.insets = new Insets( 5, 5, 5, 0 );
-		gbc_lblSettingsForDetector.fill = GridBagConstraints.HORIZONTAL;
-		gbc_lblSettingsForDetector.gridx = 0;
-		gbc_lblSettingsForDetector.gridy = 0;
-		add( lblSettingsForDetector, gbc_lblSettingsForDetector );
+		final GridBagConstraints gbcLblSettingsForDetector = new GridBagConstraints();
+		gbcLblSettingsForDetector.gridwidth = 3;
+		gbcLblSettingsForDetector.insets = new Insets( 5, 5, 5, 0 );
+		gbcLblSettingsForDetector.fill = GridBagConstraints.HORIZONTAL;
+		gbcLblSettingsForDetector.gridx = 0;
+		gbcLblSettingsForDetector.gridy = 0;
+		add( lblSettingsForDetector, gbcLblSettingsForDetector );
 
 		final JLabel lblDetector = new JLabel( TITLE, ICON, JLabel.RIGHT );
 		lblDetector.setFont( BIG_FONT );
 		lblDetector.setHorizontalAlignment( SwingConstants.CENTER );
-		final GridBagConstraints gbc_lblDetector = new GridBagConstraints();
-		gbc_lblDetector.gridwidth = 3;
-		gbc_lblDetector.insets = new Insets( 5, 5, 5, 0 );
-		gbc_lblDetector.fill = GridBagConstraints.HORIZONTAL;
-		gbc_lblDetector.gridx = 0;
-		gbc_lblDetector.gridy = 1;
-		add( lblDetector, gbc_lblDetector );
+		final GridBagConstraints gbcLblDetector = new GridBagConstraints();
+		gbcLblDetector.gridwidth = 3;
+		gbcLblDetector.insets = new Insets( 5, 5, 5, 0 );
+		gbcLblDetector.fill = GridBagConstraints.HORIZONTAL;
+		gbcLblDetector.gridx = 0;
+		gbcLblDetector.gridy = 1;
+		add( lblDetector, gbcLblDetector );
 
 		/*
 		 * Help text.
@@ -129,14 +133,14 @@ public class IlastikDetectorConfigurationPanel extends IlastikDetectorBaseConfig
 				.replace( "<p>", "<p align=\"justify\">" )
 				.replace( "<html>", "<html><p align=\"justify\">" ) );
 		lblHelptext.setFont( FONT.deriveFont( Font.ITALIC ) );
-		final GridBagConstraints gbc_lblHelptext = new GridBagConstraints();
-		gbc_lblHelptext.anchor = GridBagConstraints.NORTH;
-		gbc_lblHelptext.fill = GridBagConstraints.HORIZONTAL;
-		gbc_lblHelptext.gridwidth = 3;
-		gbc_lblHelptext.insets = new Insets( 5, 10, 5, 10 );
-		gbc_lblHelptext.gridx = 0;
-		gbc_lblHelptext.gridy = 2;
-		add( lblHelptext, gbc_lblHelptext );
+		final GridBagConstraints gbcLblHelptext = new GridBagConstraints();
+		gbcLblHelptext.anchor = GridBagConstraints.NORTH;
+		gbcLblHelptext.fill = GridBagConstraints.HORIZONTAL;
+		gbcLblHelptext.gridwidth = 3;
+		gbcLblHelptext.insets = new Insets( 5, 10, 5, 10 );
+		gbcLblHelptext.gridx = 0;
+		gbcLblHelptext.gridy = 2;
+		add( lblHelptext, gbcLblHelptext );
 
 		/*
 		 * Channel selector.
@@ -144,29 +148,29 @@ public class IlastikDetectorConfigurationPanel extends IlastikDetectorBaseConfig
 
 		final JLabel lblSegmentInChannel = new JLabel( "Segment in channel:" );
 		lblSegmentInChannel.setFont( SMALL_FONT );
-		final GridBagConstraints gbc_lblSegmentInChannel = new GridBagConstraints();
-		gbc_lblSegmentInChannel.anchor = GridBagConstraints.EAST;
-		gbc_lblSegmentInChannel.insets = new Insets( 5, 5, 5, 5 );
-		gbc_lblSegmentInChannel.gridx = 0;
-		gbc_lblSegmentInChannel.gridy = 3;
-		add( lblSegmentInChannel, gbc_lblSegmentInChannel );
+		final GridBagConstraints gbcLblSegmentInChannel = new GridBagConstraints();
+		gbcLblSegmentInChannel.anchor = GridBagConstraints.EAST;
+		gbcLblSegmentInChannel.insets = new Insets( 5, 5, 5, 5 );
+		gbcLblSegmentInChannel.gridx = 0;
+		gbcLblSegmentInChannel.gridy = 3;
+		add( lblSegmentInChannel, gbcLblSegmentInChannel );
 
 		sliderChannel = new JSlider();
-		final GridBagConstraints gbc_sliderChannel = new GridBagConstraints();
-		gbc_sliderChannel.fill = GridBagConstraints.HORIZONTAL;
-		gbc_sliderChannel.insets = new Insets( 5, 5, 5, 5 );
-		gbc_sliderChannel.gridx = 1;
-		gbc_sliderChannel.gridy = 3;
-		add( sliderChannel, gbc_sliderChannel );
+		final GridBagConstraints gbcSliderChannel = new GridBagConstraints();
+		gbcSliderChannel.fill = GridBagConstraints.HORIZONTAL;
+		gbcSliderChannel.insets = new Insets( 5, 5, 5, 5 );
+		gbcSliderChannel.gridx = 1;
+		gbcSliderChannel.gridy = 3;
+		add( sliderChannel, gbcSliderChannel );
 
 		final JLabel labelChannel = new JLabel( "1" );
 		labelChannel.setHorizontalAlignment( SwingConstants.CENTER );
 		labelChannel.setFont( SMALL_FONT );
-		final GridBagConstraints gbc_labelChannel = new GridBagConstraints();
-		gbc_labelChannel.insets = new Insets( 5, 5, 5, 0 );
-		gbc_labelChannel.gridx = 2;
-		gbc_labelChannel.gridy = 3;
-		add( labelChannel, gbc_labelChannel );
+		final GridBagConstraints gbcLabelChannel = new GridBagConstraints();
+		gbcLabelChannel.insets = new Insets( 5, 5, 5, 0 );
+		gbcLabelChannel.gridx = 2;
+		gbcLabelChannel.gridy = 3;
+		add( labelChannel, gbcLabelChannel );
 
 		sliderChannel.addChangeListener( l -> labelChannel.setText( "" + sliderChannel.getValue() ) );
 
@@ -176,32 +180,32 @@ public class IlastikDetectorConfigurationPanel extends IlastikDetectorBaseConfig
 
 		final JLabel lblCusstomModelFile = new JLabel( "ilastik file:" );
 		lblCusstomModelFile.setFont( FONT );
-		final GridBagConstraints gbc_lblCusstomModelFile = new GridBagConstraints();
-		gbc_lblCusstomModelFile.anchor = GridBagConstraints.SOUTHWEST;
-		gbc_lblCusstomModelFile.insets = new Insets( 0, 5, 0, 5 );
-		gbc_lblCusstomModelFile.gridx = 0;
-		gbc_lblCusstomModelFile.gridy = 4;
-		add( lblCusstomModelFile, gbc_lblCusstomModelFile );
+		final GridBagConstraints gbcLblCusstomModelFile = new GridBagConstraints();
+		gbcLblCusstomModelFile.anchor = GridBagConstraints.SOUTHWEST;
+		gbcLblCusstomModelFile.insets = new Insets( 0, 5, 5, 5 );
+		gbcLblCusstomModelFile.gridx = 0;
+		gbcLblCusstomModelFile.gridy = 4;
+		add( lblCusstomModelFile, gbcLblCusstomModelFile );
 
 		btnBrowse = new JButton( "Browse" );
 		btnBrowse.setFont( FONT );
-		final GridBagConstraints gbc_btnBrowse = new GridBagConstraints();
-		gbc_btnBrowse.insets = new Insets( 5, 0, 0, 5 );
-		gbc_btnBrowse.anchor = GridBagConstraints.SOUTHEAST;
-		gbc_btnBrowse.gridwidth = 2;
-		gbc_btnBrowse.gridx = 1;
-		gbc_btnBrowse.gridy = 4;
-		add( btnBrowse, gbc_btnBrowse );
+		final GridBagConstraints gbcBtnBrowse = new GridBagConstraints();
+		gbcBtnBrowse.insets = new Insets( 5, 0, 5, 0 );
+		gbcBtnBrowse.anchor = GridBagConstraints.SOUTHEAST;
+		gbcBtnBrowse.gridwidth = 2;
+		gbcBtnBrowse.gridx = 1;
+		gbcBtnBrowse.gridy = 4;
+		add( btnBrowse, gbcBtnBrowse );
 
 		modelFileTextField = new JTextField( "" );
 		modelFileTextField.setFont( SMALL_FONT );
-		final GridBagConstraints gbc_textField = new GridBagConstraints();
-		gbc_textField.gridwidth = 3;
-		gbc_textField.insets = new Insets( 0, 5, 5, 5 );
-		gbc_textField.fill = GridBagConstraints.BOTH;
-		gbc_textField.gridx = 0;
-		gbc_textField.gridy = 5;
-		add( modelFileTextField, gbc_textField );
+		final GridBagConstraints gbcTextField = new GridBagConstraints();
+		gbcTextField.gridwidth = 3;
+		gbcTextField.insets = new Insets( 0, 5, 5, 0 );
+		gbcTextField.fill = GridBagConstraints.BOTH;
+		gbcTextField.gridx = 0;
+		gbcTextField.gridy = 5;
+		add( modelFileTextField, gbcTextField );
 		modelFileTextField.setColumns( 10 );
 
 		/*
@@ -210,35 +214,23 @@ public class IlastikDetectorConfigurationPanel extends IlastikDetectorBaseConfig
 
 		final JLabel lblClassId = new JLabel( "Class index:" );
 		lblClassId.setFont( SMALL_FONT );
-		final GridBagConstraints gbc_lblOverlapThreshold = new GridBagConstraints();
-		gbc_lblOverlapThreshold.anchor = GridBagConstraints.EAST;
-		gbc_lblOverlapThreshold.insets = new Insets( 5, 5, 5, 5 );
-		gbc_lblOverlapThreshold.gridx = 0;
-		gbc_lblOverlapThreshold.gridy = 6;
-		add( lblClassId, gbc_lblOverlapThreshold );
+		final GridBagConstraints gbcLblOverlapThreshold = new GridBagConstraints();
+		gbcLblOverlapThreshold.anchor = GridBagConstraints.EAST;
+		gbcLblOverlapThreshold.insets = new Insets( 5, 5, 5, 5 );
+		gbcLblOverlapThreshold.gridx = 0;
+		gbcLblOverlapThreshold.gridy = 6;
+		add( lblClassId, gbcLblOverlapThreshold );
 
-		sliderClassId = new JSlider();
-		final GridBagConstraints gbc_sliderClassId = new GridBagConstraints();
-		gbc_sliderClassId.fill = GridBagConstraints.HORIZONTAL;
-		gbc_sliderClassId.insets = new Insets( 0, 0, 5, 5 );
-		gbc_sliderClassId.gridx = 1;
-		gbc_sliderClassId.gridy = 6;
-		add( sliderClassId, gbc_sliderClassId );
-
-		final JLabel labelClassId = new JLabel( "1" );
-		labelClassId.setHorizontalAlignment( SwingConstants.CENTER );
-		labelClassId.setFont( new Font( "Arial", Font.PLAIN, 10 ) );
-		final GridBagConstraints gbc_labelClassId = new GridBagConstraints();
-		gbc_labelClassId.insets = new Insets( 0, 0, 5, 0 );
-		gbc_labelClassId.gridx = 2;
-		gbc_labelClassId.gridy = 6;
-		add( labelClassId, gbc_labelClassId );
-
-		sliderClassId.addChangeListener( l -> labelClassId.setText( "" + sliderClassId.getValue() ) );
-		// We don't know yet how many classes we have. Let's put 10 for now.
-		sliderClassId.setMaximum( 10 );
-		sliderClassId.setMinimum( 1 );
-		sliderClassId.setValue( 1 );
+		spinner = new JSpinner( new SpinnerListModel() );
+		final DefaultEditor editor = new JSpinner.DefaultEditor( spinner );
+		editor.getTextField().setHorizontalAlignment( JTextField.CENTER );
+		spinner.setEditor( editor );
+		final GridBagConstraints gbcSpinner = new GridBagConstraints();
+		gbcSpinner.fill = GridBagConstraints.HORIZONTAL;
+		gbcSpinner.insets = new Insets( 5, 5, 5, 5 );
+		gbcSpinner.gridx = 1;
+		gbcSpinner.gridy = 6;
+		add( spinner, gbcSpinner );
 
 		/*
 		 * Proba threshold.
@@ -246,35 +238,35 @@ public class IlastikDetectorConfigurationPanel extends IlastikDetectorBaseConfig
 
 		final JLabel lblScoreTreshold = new JLabel( "Threshold on probability:" );
 		lblScoreTreshold.setFont( SMALL_FONT );
-		final GridBagConstraints gbc_lblScoreTreshold = new GridBagConstraints();
-		gbc_lblScoreTreshold.anchor = GridBagConstraints.EAST;
-		gbc_lblScoreTreshold.insets = new Insets( 5, 5, 5, 5 );
-		gbc_lblScoreTreshold.gridx = 0;
-		gbc_lblScoreTreshold.gridy = 7;
-		add( lblScoreTreshold, gbc_lblScoreTreshold );
+		final GridBagConstraints gbcLblScoreTreshold = new GridBagConstraints();
+		gbcLblScoreTreshold.anchor = GridBagConstraints.EAST;
+		gbcLblScoreTreshold.insets = new Insets( 5, 5, 5, 5 );
+		gbcLblScoreTreshold.gridx = 0;
+		gbcLblScoreTreshold.gridy = 7;
+		add( lblScoreTreshold, gbcLblScoreTreshold );
 
 		ftfProbaThreshold = new JFormattedTextField( THRESHOLD_FORMAT );
 		ftfProbaThreshold.setFont( SMALL_FONT );
 		ftfProbaThreshold.setMinimumSize( new Dimension( 60, 20 ) );
 		ftfProbaThreshold.setHorizontalAlignment( SwingConstants.CENTER );
-		final GridBagConstraints gbc_score = new GridBagConstraints();
-		gbc_score.fill = GridBagConstraints.HORIZONTAL;
-		gbc_score.insets = new Insets( 5, 5, 5, 5 );
-		gbc_score.gridx = 1;
-		gbc_score.gridy = 7;
-		add( ftfProbaThreshold, gbc_score );
+		final GridBagConstraints gbcScore = new GridBagConstraints();
+		gbcScore.fill = GridBagConstraints.HORIZONTAL;
+		gbcScore.insets = new Insets( 5, 5, 5, 5 );
+		gbcScore.gridx = 1;
+		gbcScore.gridy = 7;
+		add( ftfProbaThreshold, gbcScore );
 
 		/*
 		 * Logger.
 		 */
 
 		final JLabelLogger labelLogger = new JLabelLogger();
-		final GridBagConstraints gbc_labelLogger = new GridBagConstraints();
-		gbc_labelLogger.fill = GridBagConstraints.HORIZONTAL;
-		gbc_labelLogger.gridwidth = 3;
-		gbc_labelLogger.gridx = 0;
-		gbc_labelLogger.gridy = 10;
-		add( labelLogger, gbc_labelLogger );
+		final GridBagConstraints gbcLabelLogger = new GridBagConstraints();
+		gbcLabelLogger.fill = GridBagConstraints.HORIZONTAL;
+		gbcLabelLogger.gridwidth = 3;
+		gbcLabelLogger.gridx = 0;
+		gbcLabelLogger.gridy = 10;
+		add( labelLogger, gbcLabelLogger );
 		final Logger localLogger = labelLogger.getLogger();
 
 		/*
@@ -283,13 +275,13 @@ public class IlastikDetectorConfigurationPanel extends IlastikDetectorBaseConfig
 
 		final JButton btnPreview = new JButton( "Preview", PREVIEW_ICON );
 		btnPreview.setFont( FONT );
-		final GridBagConstraints gbc_btnPreview = new GridBagConstraints();
-		gbc_btnPreview.gridwidth = 2;
-		gbc_btnPreview.anchor = GridBagConstraints.SOUTHEAST;
-		gbc_btnPreview.insets = new Insets( 5, 5, 5, 5 );
-		gbc_btnPreview.gridx = 1;
-		gbc_btnPreview.gridy = 9;
-		add( btnPreview, gbc_btnPreview );
+		final GridBagConstraints gbcBtnPreview = new GridBagConstraints();
+		gbcBtnPreview.gridwidth = 2;
+		gbcBtnPreview.anchor = GridBagConstraints.SOUTHEAST;
+		gbcBtnPreview.insets = new Insets( 5, 5, 5, 0 );
+		gbcBtnPreview.gridx = 1;
+		gbcBtnPreview.gridy = 9;
+		add( btnPreview, gbcBtnPreview );
 
 		/*
 		 * Listeners and specificities.
@@ -345,7 +337,8 @@ public class IlastikDetectorConfigurationPanel extends IlastikDetectorBaseConfig
 
 		settings.put( KEY_CLASSIFIER_FILEPATH, modelFileTextField.getText() );
 
-		final int classID = sliderClassId.getValue() - 1;
+		final SpinnerListModel model = ( SpinnerListModel ) spinner.getModel();
+		final int classID = model.getList().indexOf( spinner.getValue() );
 		settings.put( KEY_CLASS_INDEX, classID );
 
 		final double probaThreshold = ( ( Number ) ftfProbaThreshold.getValue() ).doubleValue();
@@ -356,14 +349,20 @@ public class IlastikDetectorConfigurationPanel extends IlastikDetectorBaseConfig
 	@Override
 	public void setSettings( final Map< String, Object > settings )
 	{
-		sliderChannel.setValue( ( Integer ) settings.get( KEY_TARGET_CHANNEL ) );
-		sliderClassId.setValue( ( Integer ) settings.get( KEY_CLASS_INDEX ) + 1 );
-		ftfProbaThreshold.setValue( settings.get( KEY_PROBA_THRESHOLD ) );
-		
 		String filePath = ( String ) settings.get( KEY_CLASSIFIER_FILEPATH );
 		if ( filePath == null || filePath.isEmpty() )
 			filePath = prefService.get( IlastikDetectorConfigurationPanel.class, KEY_CLASSIFIER_FILEPATH );
 		modelFileTextField.setText( filePath );
+
+		sliderChannel.setValue( ( Integer ) settings.get( KEY_TARGET_CHANNEL ) );
+
+		refreshLabelNames();
+		final SpinnerListModel model = ( SpinnerListModel ) spinner.getModel();
+		final int classID = ( Integer ) settings.get( KEY_CLASS_INDEX );
+		spinner.setValue( model.getList().get( classID ) );
+
+		ftfProbaThreshold.setValue( settings.get( KEY_PROBA_THRESHOLD ) );
+
 	}
 
 	@Override
@@ -387,11 +386,36 @@ public class IlastikDetectorConfigurationPanel extends IlastikDetectorBaseConfig
 			{
 				modelFileTextField.setText( file.getAbsolutePath() );
 				prefService.put( IlastikDetectorConfigurationPanel.class, KEY_CLASSIFIER_FILEPATH, file.getAbsolutePath() );
+				refreshLabelNames();
 			}
 		}
 		finally
 		{
 			btnBrowse.setEnabled( true );
 		}
+	}
+
+	private void refreshLabelNames()
+	{
+		final String path = modelFileTextField.getText();
+		// Store current selection index.
+		final int currentIndex = ( ( SpinnerListModel ) spinner.getModel() )
+				.getList().indexOf( spinner.getValue() );
+
+		// Get new list of labels.
+		final List< String > classLabels = IlastikRunner.getClassLabels( path );
+		if ( classLabels == null || classLabels.isEmpty() )
+			return;
+
+		// Regen model.
+		final SpinnerListModel spinnerModel = new SpinnerListModel( classLabels );
+		spinner.setModel( spinnerModel );
+		if ( currentIndex >= 0 && currentIndex < classLabels.size() )
+			spinnerModel.setValue( classLabels.get( currentIndex ) );
+
+		// Regen UI.
+		final JFormattedTextField tf = ( ( JSpinner.DefaultEditor ) spinner.getEditor() ).getTextField();
+		tf.revalidate();
+		tf.repaint();
 	}
 }

--- a/src/main/java/fiji/plugin/trackmate/ilastik/IlastikDetectorFactory.java
+++ b/src/main/java/fiji/plugin/trackmate/ilastik/IlastikDetectorFactory.java
@@ -48,11 +48,8 @@ import fiji.plugin.trackmate.detection.SpotGlobalDetector;
 import fiji.plugin.trackmate.detection.SpotGlobalDetectorFactory;
 import fiji.plugin.trackmate.gui.components.ConfigurationPanel;
 import fiji.plugin.trackmate.io.IOUtils;
-import fiji.plugin.trackmate.util.TMUtils;
 import net.imagej.ImgPlus;
-import net.imagej.axis.Axes;
 import net.imglib2.Interval;
-import net.imglib2.img.display.imagej.ImgPlusViews;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 
@@ -132,16 +129,16 @@ public class IlastikDetectorFactory< T extends RealType< T > & NativeType< T > >
 	@Override
 	public SpotGlobalDetector< T > getDetector( final Interval interval )
 	{
-		final double[] calibration = TMUtils.getSpatialCalibration( img );
 		final String classifierPath = ( String ) settings.get( KEY_CLASSIFIER_FILEPATH );
-		final ImgPlus< T > imFrame = prepareImg();
 		final int classIndex = ( Integer ) settings.get( KEY_CLASS_INDEX );
 		final double probaThreshold = ( Double ) settings.get( KEY_PROBA_THRESHOLD );
+		// In ImgLib2, dimensions are 0-based.
+		final int channel = ( Integer ) settings.get( KEY_TARGET_CHANNEL ) - 1;
 
 		final IlastikDetector< T > detector = new IlastikDetector<>(
-				imFrame,
+				img,
 				interval,
-				calibration,
+				channel,
 				classifierPath,
 				classIndex,
 				probaThreshold );
@@ -283,28 +280,6 @@ public class IlastikDetectorFactory< T extends RealType< T > & NativeType< T > >
 	public String getName()
 	{
 		return NAME;
-	}
-
-	/**
-	 * Return 1-channel, all time-points, all-Zs if any.
-	 * 
-	 * @return an {@link ImgPlus}.
-	 */
-	protected ImgPlus< T > prepareImg()
-	{
-		final int cDim = img.dimensionIndex( Axes.CHANNEL );
-		final ImgPlus< T > imFrame;
-		if ( cDim < 0 )
-		{
-			imFrame = img;
-		}
-		else
-		{
-			// In ImgLib2, dimensions are 0-based.
-			final int channel = ( Integer ) settings.get( KEY_TARGET_CHANNEL ) - 1;
-			imFrame = ImgPlusViews.hyperSlice( img, cDim, channel );
-		}
-		return imFrame;
 	}
 
 	@Override

--- a/src/main/java/fiji/plugin/trackmate/ilastik/IlastikRunner.java
+++ b/src/main/java/fiji/plugin/trackmate/ilastik/IlastikRunner.java
@@ -62,7 +62,6 @@ import net.imglib2.img.display.imagej.ImgPlusViews;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.Type;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.util.Util;
 import net.imglib2.view.Views;
 
 public class IlastikRunner
@@ -158,16 +157,11 @@ public class IlastikRunner
 		 * Properly set the image to process: crop it.
 		 */
 
-		System.out.println( Util.printInterval( extendedInterval ) ); // DEBUG
-		System.out.println( Util.printInterval( input ) ); // DEBUG
-
 		final RandomAccessibleInterval< T > crop = Views.interval( input, extendedInterval );
 		final RandomAccessibleInterval< T > zeroMinCrop = Views.zeroMin( crop );
 
 		final ImgPlus< T > cropped = new ImgPlus<>( ImgView.wrap( zeroMinCrop, input.factory() ) );
 		MetadataUtil.copyImgPlusMetadata( input, cropped );
-
-		System.out.println( Util.printInterval( cropped ) ); // DEBUG
 
 		/*
 		 * Discover and use Ilastik config.

--- a/src/main/java/fiji/plugin/trackmate/ilastik/IlastikRunner.java
+++ b/src/main/java/fiji/plugin/trackmate/ilastik/IlastikRunner.java
@@ -268,9 +268,8 @@ public class IlastikRunner
 	private static final int getModelNChannel( final String path )
 	{
 		final IHDF5Reader reader = HDF5Factory.openForReading( new File( path ) );
-
 		final HDF5ObjectInformation info = reader.object().getObjectInformation( HDF_PATH_AXISTAGS );
-		if ( !info.isDataSet() )
+		if ( !info.exists() )
 			return 1; // assume there is only 1 channel
 
 		final String str = reader.readString( HDF_PATH_AXISTAGS );

--- a/src/main/java/fiji/plugin/trackmate/ilastik/IlastikRunner.java
+++ b/src/main/java/fiji/plugin/trackmate/ilastik/IlastikRunner.java
@@ -23,6 +23,7 @@ package fiji.plugin.trackmate.ilastik;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -303,6 +304,7 @@ public class IlastikRunner
 
 	private static final String HDF_PATH_SHAPE = "/Input Data/infos/lane0000/Raw Data/shape";
 
+
 	private static final Gson createJSon()
 	{
 		return new GsonBuilder()
@@ -322,4 +324,17 @@ public class IlastikRunner
 			return Collections.singletonMap( AXES_KEY, deserialize );
 		}
 	}
+
+	public static List< String > getClassLabels( final String path )
+	{
+		final IHDF5Reader reader = HDF5Factory.openForReading( new File( path ) );
+		final HDF5ObjectInformation info = reader.object().getObjectInformation( HDF_PATH_LABELNAMES );
+		if ( !info.exists() )
+			return null; // We failed to read.
+
+		final String[] arr = reader.readStringArray( HDF_PATH_LABELNAMES );
+		return Arrays.asList( arr );
+	}
+
+	private static final String HDF_PATH_LABELNAMES = "/PixelClassification/LabelNames";
 }

--- a/src/main/java/fiji/plugin/trackmate/ilastik/IlastikRunner.java
+++ b/src/main/java/fiji/plugin/trackmate/ilastik/IlastikRunner.java
@@ -23,7 +23,9 @@ package fiji.plugin.trackmate.ilastik;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.ilastik.ilastik4ij.executors.AbstractIlastikExecutor.PixelPredictionType;
 import org.ilastik.ilastik4ij.executors.PixelClassification;
@@ -33,6 +35,17 @@ import org.scijava.app.StatusService;
 import org.scijava.log.LogService;
 import org.scijava.options.OptionsService;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import ch.systemsx.cisd.hdf5.HDF5Factory;
+import ch.systemsx.cisd.hdf5.HDF5ObjectInformation;
+import ch.systemsx.cisd.hdf5.IHDF5Reader;
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.SpotCollection;
 import fiji.plugin.trackmate.detection.DetectionUtils;
@@ -41,12 +54,15 @@ import fiji.plugin.trackmate.util.TMUtils;
 import net.imagej.ImgPlus;
 import net.imagej.axis.Axes;
 import net.imagej.ops.MetadataUtil;
+import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.ImgView;
 import net.imglib2.img.display.imagej.ImgPlusViews;
 import net.imglib2.type.NativeType;
+import net.imglib2.type.Type;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
 import net.imglib2.view.Views;
 
 public class IlastikRunner
@@ -60,13 +76,79 @@ public class IlastikRunner
 	 *             if the Ilastik file cannot be found.
 	 */
 	public static < T extends RealType< T > & NativeType< T > > SpotCollection run(
-			final ImgPlus< T > input,
+			final ImgPlus< T > img,
 			final Interval interval,
-			final double[] calibration,
+			final int channel,
 			final String projectFilePath,
 			final long classId,
 			final double probaThreshold ) throws IOException
 	{
+		/*
+		 * Investigate whether the ilastik model is built on a single channel or
+		 * on multiple channels.
+		 */
+
+		final ImgPlus< T > input;
+		final Interval extendedInterval;
+		final int modelNChannel = getModelNChannel( projectFilePath );
+		if ( modelNChannel > 1 )
+		{
+			/*
+			 * The model was trained on images with more that one channel. In
+			 * that case we assume that the image to perform inference has the
+			 * same number of channel with the same order, and we pass it whole
+			 * to ilastik.
+			 */
+			input = img;
+			final long[] min = new long[ input.numDimensions() ];
+			final long[] max = new long[ input.numDimensions() ];
+			// Source interval is always x, y, z (if any), t.
+			int axisidSource = 0;
+			int axisidTarget = 0;
+			// X
+			min[ axisidSource ] = interval.min( axisidTarget );
+			max[ axisidSource ] = interval.max( axisidTarget );
+			// Y
+			axisidSource++;
+			axisidTarget++;
+			min[ axisidSource ] = interval.min( axisidTarget );
+			max[ axisidSource ] = interval.max( axisidTarget );
+			// Z.
+			if ( img.dimensionIndex( Axes.Z ) >= 0 )
+			{
+				axisidSource++;
+				axisidTarget++;
+				min[ axisidSource ] = interval.min( axisidTarget );
+				max[ axisidSource ] = interval.max( axisidTarget );
+			}
+			// C - not present in the source interval.
+			final int caxis = img.dimensionIndex( Axes.CHANNEL );
+			if ( caxis >= 0 )
+			{
+				// If we do not have channel axis here, we are screwed anyway.
+				axisidSource++;
+				min[ axisidSource ] = img.min( caxis );
+				max[ axisidSource ] = img.max( caxis );
+			}
+			// T
+			axisidSource++;
+			axisidTarget++;
+			min[ axisidSource ] = interval.min( axisidTarget );
+			max[ axisidSource ] = interval.max( axisidTarget );
+
+			extendedInterval = FinalInterval.wrap( min, max );
+		}
+		else
+		{
+			/*
+			 * The model was trained on images with one channel. In that case we
+			 * make it possible to apply it on one of the channel of the
+			 * possibly multi-channel input image. We extract the channel
+			 * specified by the user and pass it to ilastik.
+			 */
+			input = prepareImg( img, channel );
+			extendedInterval = interval;
+		}
 
 		final LogService logService = context.getService( LogService.class );
 		final StatusService statusService = context.getService( StatusService.class );
@@ -76,11 +158,16 @@ public class IlastikRunner
 		 * Properly set the image to process: crop it.
 		 */
 
-		final RandomAccessibleInterval< T > crop = Views.interval( input, interval );
+		System.out.println( Util.printInterval( extendedInterval ) ); // DEBUG
+		System.out.println( Util.printInterval( input ) ); // DEBUG
+
+		final RandomAccessibleInterval< T > crop = Views.interval( input, extendedInterval );
 		final RandomAccessibleInterval< T > zeroMinCrop = Views.zeroMin( crop );
 
 		final ImgPlus< T > cropped = new ImgPlus<>( ImgView.wrap( zeroMinCrop, input.factory() ) );
 		MetadataUtil.copyImgPlusMetadata( input, cropped );
+
+		System.out.println( Util.printInterval( cropped ) ); // DEBUG
 
 		/*
 		 * Discover and use Ilastik config.
@@ -105,7 +192,6 @@ public class IlastikRunner
 				maxRamMb );
 		final PixelPredictionType predictionType = PixelPredictionType.Probabilities;
 
-
 		final ImgPlus< T > output = classifier.classifyPixels( cropped, predictionType );
 		final ImgPlus< T > proba = ImgPlusViews.hyperSlice( output, output.dimensionIndex( Axes.CHANNEL ), classId );
 
@@ -113,9 +199,10 @@ public class IlastikRunner
 		 * Create ROIs from proba.
 		 */
 
+		final double[] calibration = TMUtils.getSpatialCalibration( img );
 		final SpotCollection spots = new SpotCollection();
 		final int timeIndex = proba.dimensionIndex( Axes.TIME );
-		final int t0 = interval.numDimensions() > 2 ? ( int ) interval.min( 2 ) : 0;
+		final int t0 = extendedInterval.numDimensions() > 2 ? ( int ) extendedInterval.min( 2 ) : 0;
 		for ( int t = 0; t < proba.dimension( timeIndex ); t++ )
 		{
 			final List< Spot > spotsThisFrame;
@@ -130,10 +217,10 @@ public class IlastikRunner
 				spotsThisFrame = MaskUtils.fromThresholdWithROI(
 						probaThisFrame,
 						probaThisFrame,
-						calibration, 
-						probaThreshold, 
-						simplify, 
-						numThreads, 
+						calibration,
+						probaThreshold,
+						simplify,
+						numThreads,
 						probaThisFrame );
 			}
 			else
@@ -160,7 +247,7 @@ public class IlastikRunner
 				for ( int d = 0; d < maxD; d++ )
 				{
 					final double pos = spot.getDoublePosition( d );
-					final double newPos = pos + interval.min( d ) * calibration[ d ];
+					final double newPos = pos + extendedInterval.min( d ) * calibration[ d ];
 					spot.putFeature( Spot.POSITION_FEATURES[ d ], newPos );
 				}
 			}
@@ -168,5 +255,78 @@ public class IlastikRunner
 			spots.put( t + t0, spotsThisFrame );
 		}
 		return spots;
+	}
+
+	/**
+	 * Return 1-channel, all time-points, all-Zs if any.
+	 * 
+	 * @return an {@link ImgPlus}.
+	 */
+	private static < T extends Type< T > > ImgPlus< T > prepareImg( final ImgPlus< T > img, final int channel )
+	{
+		final int cDim = img.dimensionIndex( Axes.CHANNEL );
+		if ( cDim < 0 )
+			return img;
+		else
+			return ImgPlusViews.hyperSlice( img, cDim, channel );
+	}
+
+	private static final int getModelNChannel( final String path )
+	{
+		final IHDF5Reader reader = HDF5Factory.openForReading( new File( path ) );
+
+		final HDF5ObjectInformation info = reader.object().getObjectInformation( HDF_PATH_AXISTAGS );
+		if ( !info.isDataSet() )
+			return 1; // assume there is only 1 channel
+
+		final String str = reader.readString( HDF_PATH_AXISTAGS );
+		@SuppressWarnings( "unchecked" )
+		final Map< String, List< Map< String, String > > > map = createJSon().fromJson( str, Map.class );
+		final List< Map< String, String > > axesList = map.get( "axes" );
+		int channelAxis = -1;
+		for ( int i = 0; i < axesList.size(); i++ )
+		{
+			final Map< String, String > axesAttributes = axesList.get( i );
+			final String axisStr = axesAttributes.get( AXIS_KEY_KEY );
+			if ( CHANNEL_AXIS_NAME.equals( axisStr ) )
+			{
+				channelAxis = i;
+				break;
+			}
+		}
+		if ( channelAxis < 0 )
+			return 1;
+		final int[] shape = reader.readIntArray( HDF_PATH_SHAPE );
+		return shape[ channelAxis ];
+	}
+
+	private static final String AXES_KEY = "axes";
+
+	private static final String AXIS_KEY_KEY = "key";
+
+	private static final String CHANNEL_AXIS_NAME = "c";
+
+	private static final String HDF_PATH_AXISTAGS = "/Input Data/infos/lane0000/Raw Data/axistags";
+
+	private static final String HDF_PATH_SHAPE = "/Input Data/infos/lane0000/Raw Data/shape";
+
+	private static final Gson createJSon()
+	{
+		return new GsonBuilder()
+				.registerTypeAdapter( Map.class, new IlastikAxisMapAdapter() )
+				.create();
+	}
+
+	private static class IlastikAxisMapAdapter implements JsonDeserializer< Map< String, List< Map< String, String > > > >
+	{
+
+		@Override
+		public Map< String, List< Map< String, String > > > deserialize( final JsonElement json, final java.lang.reflect.Type typeOfT, final JsonDeserializationContext context ) throws JsonParseException
+		{
+			final JsonObject obj = json.getAsJsonObject();
+			final JsonElement str = obj.get( AXES_KEY );
+			final List< Map< String, String > > deserialize = context.deserialize( str, List.class );
+			return Collections.singletonMap( AXES_KEY, deserialize );
+		}
 	}
 }

--- a/src/test/java/fiji/plugin/trackmate/ImportIlastikModelTestDrive.java
+++ b/src/test/java/fiji/plugin/trackmate/ImportIlastikModelTestDrive.java
@@ -92,6 +92,5 @@ public class ImportIlastikModelTestDrive
 			final List< Map< String, String > > deserialize = context.deserialize( str, List.class );
 			return Collections.singletonMap( AXES_KEY, deserialize );
 		}
-
 	}
 }

--- a/src/test/java/fiji/plugin/trackmate/ImportIlastikModelTestDrive.java
+++ b/src/test/java/fiji/plugin/trackmate/ImportIlastikModelTestDrive.java
@@ -1,0 +1,97 @@
+package fiji.plugin.trackmate;
+
+import java.io.File;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import ch.systemsx.cisd.hdf5.HDF5Factory;
+import ch.systemsx.cisd.hdf5.HDF5ObjectInformation;
+import ch.systemsx.cisd.hdf5.IHDF5Reader;
+import net.imglib2.util.Util;
+
+public class ImportIlastikModelTestDrive
+{
+
+	private static final String AXES_KEY = "axes";
+
+	private static final String AXIS_KEY_KEY = "key";
+
+	private static final String CHANNEL_AXIS_NAME = "c";
+
+	private static final String HDF_PATH_AXISTAGS = "/Input Data/infos/lane0000/Raw Data/axistags";
+
+	private static final String HDF_PATH_SHAPE = "/Input Data/infos/lane0000/Raw Data/shape";
+
+	public static void main( final String[] args )
+	{
+		final String path = "D:\\Projects\\LLeBlanc\\Data\\MyProject_2ch_2cl.ilp";
+		final IHDF5Reader reader = HDF5Factory.openForReading( new File( path ) );
+
+		final HDF5ObjectInformation info = reader.object().getObjectInformation( HDF_PATH_AXISTAGS );
+		if ( !info.isDataSet() )
+		{
+			System.out.println( "Could not find axes model metadata in the project file. Skipping." );
+			return;
+		}
+
+		final String str = reader.readString( HDF_PATH_AXISTAGS );
+		@SuppressWarnings( "unchecked" )
+		final Map< String, List< Map< String, String > > > map = createJSon().fromJson( str, Map.class );
+		final List< Map< String, String > > axesList = map.get( "axes" );
+		int channelAxis = -1;
+		for ( int i = 0; i < axesList.size(); i++ )
+		{
+			final Map< String, String > axesAttributes = axesList.get( i );
+			final String axisStr = axesAttributes.get( AXIS_KEY_KEY );
+			if ( CHANNEL_AXIS_NAME.equals( axisStr ) )
+			{
+				channelAxis = i;
+				break;
+			}
+		}
+		if ( channelAxis < 0 )
+		{
+			System.out.println( "Could not find the axis for channel in the model. Skipping." );
+			return;
+		}
+		System.out.println( "Channel axis is at index " + channelAxis );
+
+		final int[] shape = reader.readIntArray( HDF_PATH_SHAPE );
+		System.out.println( "Shape: " + Util.printCoordinates( shape ) );
+		System.out.println( "Number of channels in the model: " + shape[ channelAxis ] );
+	}
+
+	private static final Gson createJSon()
+	{
+		return new GsonBuilder()
+				.registerTypeAdapter( Map.class, new IlastikAxisMapAdapter() )
+				.create();
+	}
+
+	private static class IlastikAxisMapAdapter implements JsonDeserializer< Map< String, List< Map< String, String > > > >
+	{
+
+		@Override
+		public Map< String, List< Map< String, String > > > deserialize(
+				final JsonElement json,
+				final Type typeOfT,
+				final JsonDeserializationContext context ) throws JsonParseException
+		{
+			final JsonObject obj = json.getAsJsonObject();
+			final JsonElement str = obj.get( AXES_KEY );
+			final List< Map< String, String > > deserialize = context.deserialize( str, List.class );
+			return Collections.singletonMap( AXES_KEY, deserialize );
+		}
+
+	}
+}

--- a/src/test/java/fiji/plugin/trackmate/TrackMateIlastikTestDrive.java
+++ b/src/test/java/fiji/plugin/trackmate/TrackMateIlastikTestDrive.java
@@ -33,7 +33,8 @@ public class TrackMateIlastikTestDrive
 	{
 		final ImageJ ij = new ImageJ();
 		ij.launch( args );
-		final String path = "D:\\Projects\\NVerttiQuintero\\Data\\Series014b.tif";
+//		final String path = "D:\\Projects\\NVerttiQuintero\\Data\\Series014b.tif";
+		final String path = "D:\\Projects\\LLeBlanc\\Data\\201125_Proliferation_2C43-PilQmCherry-HupmRhubarb-II4_100X_timestep5min_Stage3_reg.tif";
 //		"D:/Projects/NVerttiQuintero/Data/Series014b.tif"
 		final Dataset dataset = ( Dataset ) ij.io().open( path );
 		ij.ui().show( dataset );


### PR DESCRIPTION
The TrackMate-Ilastik detector crashes if it is used with an ilastik project containing a model trained on images
with more than one channel. The TrackMate module always crop the source image to pass a single-
channel image to ilastik (this is the 'segment in channel' setting), and of course that would make ilastik unhappy if the model was expecting a multi-channel image.

This PR fixes this, retaining compatibility with previous features:

- First the ilastik runner inspects the ilastik project file and checks on how many channels the model was trained on.
- If it is 1, then the TrackMate module crops the input to only pass the specified channel to ilastik and everything is fine.

- If there is more than 1, then TrackMate passes the full input image to ilastik. For this to work, there must be the same number of channels in the training images than in the input image, and they must be at the same position. This is a normal expectation but it does not cost much to remind it. When it is the case, the TrackMate ilastik module works as expected.
